### PR TITLE
Fix link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is the code that powers [@RoofSlappingBot](https://twitter.com/RoofSlappingBot).
 
-All of the magic is in `data.json`, which I more or less manually scraped from [ConceptNet](https://conceptnet.io).
+All of the magic is in `data.json`, which I more or less manually scraped from [ConceptNet](http://conceptnet.io).
 
 This code is designed to be run on a schedule, once every X hours, as a cron job.
 


### PR DESCRIPTION
https link isn't working for conceptnet.io, changed to http.